### PR TITLE
20230519 fixes

### DIFF
--- a/src/django_peerctl/models/peerctl.py
+++ b/src/django_peerctl/models/peerctl.py
@@ -19,10 +19,9 @@ from django.utils.html import strip_tags
 from django.utils.translation import gettext as _
 from django_countries.fields import CountryField
 from django_grainy.decorators import grainy_model
-from django_handleref.models import HandleRefModel
 from django_inet.models import ASNField
 from fullctl.django.fields.service_bridge import ReferencedObjectField
-from fullctl.django.models.abstract import meta
+from fullctl.django.models.abstract import meta, HandleRefModel
 from fullctl.django.models.concrete import Instance, Organization  # noqa
 from fullctl.django.validators import ip_address_string
 from fullctl.service_bridge.data import Relationships
@@ -916,7 +915,7 @@ class PortObject(devicectl.DeviceCtlEntity, PolicyHolderMixin):
             peer_sessions = PeerSession.objects.filter(port=self.pk)
             self._peer_session_qs_prefetched = peer_sessions.select_related(
                 "peer_port", "peer_port__port_info", "peer_port__peer_net"
-            ).all()
+            ).exclude(status="deleted")
         return self._peer_session_qs_prefetched
 
     def set_policy(self, *args, **kwargs):
@@ -982,6 +981,7 @@ class PortObject(devicectl.DeviceCtlEntity, PolicyHolderMixin):
                         return peer_session
                 except ValueError:
                     pass
+
         except PeerSession.DoesNotExist:
             return None
         return None

--- a/src/django_peerctl/models/peerctl.py
+++ b/src/django_peerctl/models/peerctl.py
@@ -21,7 +21,7 @@ from django_countries.fields import CountryField
 from django_grainy.decorators import grainy_model
 from django_inet.models import ASNField
 from fullctl.django.fields.service_bridge import ReferencedObjectField
-from fullctl.django.models.abstract import meta, HandleRefModel
+from fullctl.django.models.abstract import HandleRefModel, meta
 from fullctl.django.models.concrete import Instance, Organization  # noqa
 from fullctl.django.validators import ip_address_string
 from fullctl.service_bridge.data import Relationships
@@ -971,13 +971,23 @@ class PortObject(devicectl.DeviceCtlEntity, PolicyHolderMixin):
         try:
             for peer_session in self.peer_session_qs_prefetched:
                 try:
-                    if ipaddress.ip_interface(member.ipaddr4).ip == ipaddress.ip_interface(peer_session.peer_port.port_info.ipaddr4).ip:
+                    if (
+                        ipaddress.ip_interface(member.ipaddr4).ip
+                        == ipaddress.ip_interface(
+                            peer_session.peer_port.port_info.ipaddr4
+                        ).ip
+                    ):
                         return peer_session
                 except ValueError:
                     pass
 
                 try:
-                    if ipaddress.ip_interface(member.ipaddr6).ip == ipaddress.ip_interface(peer_session.peer_port.port_info.ipaddr6).ip:
+                    if (
+                        ipaddress.ip_interface(member.ipaddr6).ip
+                        == ipaddress.ip_interface(
+                            peer_session.peer_port.port_info.ipaddr6
+                        ).ip
+                    ):
                         return peer_session
                 except ValueError:
                     pass

--- a/src/django_peerctl/models/peerctl.py
+++ b/src/django_peerctl/models/peerctl.py
@@ -971,8 +971,17 @@ class PortObject(devicectl.DeviceCtlEntity, PolicyHolderMixin):
         """
         try:
             for peer_session in self.peer_session_qs_prefetched:
-                if peer_session.peer_port.port_info.ref_id == member.ref_id:
-                    return peer_session
+                try:
+                    if ipaddress.ip_interface(member.ipaddr4).ip == ipaddress.ip_interface(peer_session.peer_port.port_info.ipaddr4).ip:
+                        return peer_session
+                except ValueError:
+                    pass
+
+                try:
+                    if ipaddress.ip_interface(member.ipaddr6).ip == ipaddress.ip_interface(peer_session.peer_port.port_info.ipaddr6).ip:
+                        return peer_session
+                except ValueError:
+                    pass
         except PeerSession.DoesNotExist:
             return None
         return None

--- a/src/django_peerctl/rest/serializers/peerctl.py
+++ b/src/django_peerctl/rest/serializers/peerctl.py
@@ -705,14 +705,14 @@ class UpdatePeerSession(serializers.Serializer):
         help_text=_("Interface name of the peer port"),
     )
     peer_session_type = serializers.CharField(default="peer", required=False)
-    policy_4 = serializers.IntegerField(
+    policy4 = serializers.IntegerField(
         required=False,
         allow_null=True,
         help_text=_(
             "IPv4 Policy - session will use this peering policy, should be policy id"
         ),
     )
-    policy_6 = serializers.IntegerField(
+    policy6 = serializers.IntegerField(
         required=False,
         allow_null=True,
         help_text=_(
@@ -758,8 +758,8 @@ class UpdatePeerSession(serializers.Serializer):
     class Meta:
         fields = [
             "id",
-            "policy_4",
-            "policy_6",
+            "policy4",
+            "policy6",
             "md5",
             "peer_asn",
             "peer_ip4",
@@ -921,8 +921,8 @@ class UpdatePeerSession(serializers.Serializer):
             port=port_id,
             device=device_id,
             peer_port=peer_port,
-            policy4_id=data.get("policy_4") or None,
-            policy6_id=data.get("policy_6") or None,
+            policy4_id=data.get("policy4") or None,
+            policy6_id=data.get("policy6") or None,
             status="ok",
             peer_session_type=data["peer_session_type"] or "peer",
             meta4=data.get("meta4") or None,
@@ -975,11 +975,11 @@ class UpdatePeerSession(serializers.Serializer):
         if "port" in data:
             session.port = data["port"]
 
-        if "policy_4" in data:
-            session.policy4_id = data["policy_4"]
+        if "policy4" in data:
+            session.policy4_id = data["policy4"]
 
-        if "policy_6" in data:
-            session.policy6_id = data["policy_6"]
+        if "policy6" in data:
+            session.policy6_id = data["policy6"]
 
         if "peer_session_type" in data:
             session.peer_session_type = data["peer_session_type"]

--- a/src/django_peerctl/rest/serializers/peerctl.py
+++ b/src/django_peerctl/rest/serializers/peerctl.py
@@ -853,6 +853,8 @@ class UpdatePeerSession(serializers.Serializer):
             ip_address_6=data.get("peer_ip6"),
         )
 
+        
+
         peer = models.Network.get_or_create(asn=data["peer_asn"], org=None)
 
         peer_net = models.PeerNetwork.get_or_create(net, peer)

--- a/src/django_peerctl/rest/serializers/peerctl.py
+++ b/src/django_peerctl/rest/serializers/peerctl.py
@@ -853,8 +853,6 @@ class UpdatePeerSession(serializers.Serializer):
             ip_address_6=data.get("peer_ip6"),
         )
 
-        
-
         peer = models.Network.get_or_create(asn=data["peer_asn"], org=None)
 
         peer_net = models.PeerNetwork.get_or_create(net, peer)

--- a/src/django_peerctl/rest/views/peerctl.py
+++ b/src/django_peerctl/rest/views/peerctl.py
@@ -1117,11 +1117,11 @@ class UpdatePeerSession(CachedObjectMixin, viewsets.ModelViewSet):
         if "peer_maxprefix6" in data and not data["peer_maxprefix6"]:
             data.pop("peer_maxprefix6")
 
-        if "policy_4" in data and not data["policy_4"]:
-            data.pop("policy_4")
+        if "policy4" in data and not data["policy4"]:
+            data.pop("policy4")
 
-        if "policy_6" in data and not data["policy_6"]:
-            data.pop("policy_6")
+        if "policy6" in data and not data["policy6"]:
+            data.pop("policy6")
 
         if "id" in data and not data["id"]:
             data.pop("id")

--- a/src/django_peerctl/rest/views/peerctl.py
+++ b/src/django_peerctl/rest/views/peerctl.py
@@ -603,8 +603,9 @@ class SessionsSummary(CachedObjectMixin, viewsets.GenericViewSet):
         peer_session = models.PeerSession.objects.get(
             id=pk, peer_port__peer_net__net=net
         )
+        response = Response(self.serializer_class(peer_session).data)
         peer_session.delete()
-        return Response(self.serializer_class(peer_session).data)
+        return response
 
 
 @route
@@ -658,18 +659,18 @@ class Peer(CachedObjectMixin, viewsets.GenericViewSet):
         )
 
     @load_object("net", models.Network, asn="asn")
-    @load_object("port", models.Port, id="port_pk")
     @grainy_endpoint(namespace="verified.asn.{asn}.?")
-    def retrieve(self, request, asn, net, port_pk, port, pk, *args, **kwargs):
+    def retrieve(self, request, asn, net, port_pk, pk, *args, **kwargs):
+        port = models.Port().object(port_pk)
         peer = get_member(pk)
         serializer = self.serializer_class(peer, context={"port": port, "net": net})
         return Response(serializer.data)
-
+    
     @action(detail=True, methods=["get"])
     @load_object("net", models.Network, asn="asn")
-    @load_object("port", models.Port, id="port_pk")
     @grainy_endpoint(namespace="verified.asn.{asn}.?")
-    def details(self, request, asn, net, port_pk, port, pk, *args, **kwargs):
+    def details(self, request, asn, net, port_pk, pk, *args, **kwargs):
+        port = models.Port().object(port_pk)
         peer = get_member(pk)
         serializer = Serializers.peerdetail(peer, context={"port": port, "net": net})
         return Response(serializer.data)
@@ -879,27 +880,16 @@ class PeerSession(CachedObjectMixin, viewsets.ModelViewSet):
     require_asn = True
     require_port = True
 
-    def get_serializer_dynamic(self, path, method, direction):
-        """
-        Retrieve correct serializer class for openapi schema
-        generation
-        """
-
-        if path == "/api/peer_session/{asn}/{port_pk}/create_floating/":
-            return Serializers.update_peer_session()
-        elif path == "/api/peer_session/{asn}/{port_pk}/{id}/update_meta/":
-            return Serializers.update_peer_session_meta()
-        elif method == "PUT":
-            return Serializers.update_peer_session()
-
-        return Serializers.peer_session()
-
     @load_object("net", models.Network, asn="asn")
     @grainy_endpoint(namespace="verified.asn.{asn}.?")
     def create(self, request, asn, net, port_pk, *args, **kwargs):
         data = request.data
 
-        port = models.Port().first(id=port_pk)
+        port = models.Port().first(id=port_pk, org_slug=net.org.slug)
+
+        if not port:
+            return Response({}, status=404)
+
 
         member = get_member(data.get("member"), join="ix")
 
@@ -911,23 +901,29 @@ class PeerSession(CachedObjectMixin, viewsets.ModelViewSet):
         if not data.get("peer_asn"):
             data["peer_asn"] = 0
 
-        peer_port = models.PeerPort.get_or_create_from_members(
-            port.port_info_object.ref, member
+        # check if session exists
+
+        print("IP4", member.ipaddr4)
+
+        session_exists = models.PeerSession.get_unique(
+            asn,
+            port.device_id,
+            member.asn,
+            member.ipaddr4 or member.ipaddr6,
         )
 
-        # XXX aaactl metered limiting
-        # try:
-        #    port.port_info.net.validate_limits()
-        # except UsageLimitError as exc:
-        #    raise ValidationError(
-        #        {"non_field_errors": [["usage_limit", "{}".format(exc)]]}
-        #    )
+        print("SESSION EXISTS", session_exists)
 
-        instance = models.PeerSession.get_or_create(port, peer_port)
-        instance.status = "ok"
-        instance.save()
+        if not session_exists:
+            peer_port = models.PeerPort.get_or_create_from_members(
+                port.port_info_object.ref, member
+            )
 
-        models.AuditLog.log_peer_session_add(instance, request.user)
+            instance = models.PeerSession.get_or_create(port, peer_port)
+            instance.status = "ok"
+            instance.save()
+
+            models.AuditLog.log_peer_session_add(instance, request.user)
 
         serializer = Serializers.peer(
             through_member, context={"port": port, "net": net}
@@ -964,107 +960,11 @@ class PeerSession(CachedObjectMixin, viewsets.ModelViewSet):
         port = models.Port().object(port_pk)
         peer_session = models.PeerSession.objects.get(id=pk)
 
+        response = Response(self.serializer_class(peer_session).data)
+
         if peer_session.port and int(peer_session.port.id) == int(port_pk):
             super().destroy(request, asn, port, pk)
-        return Response(self.serializer_class(peer_session).data)
-
-    @action(
-        detail=False,
-        methods=["post"],
-        serializer_class=Serializers.update_peer_session,
-    )
-    @load_object("net", models.Network, asn="asn")
-    @grainy_endpoint(namespace="verified.asn.{asn}.?")
-    def create_floating(self, request, asn, net, port_pk, *args, **kwargs):
-        """
-        Creates a new peering session.
-
-        Note that unless you set at minimum the following:
-
-        - peer ipv4 or ipv6 address
-        - peer type
-        - peer asn
-        - ipv4 or ipv6 policy
-        - port
-
-        the session will come back with status `partial`
-
-        You may update / finish configuration of partial sessions using the PUT request
-        the peer session API
-        """
-
-        data = request.data.copy()
-
-        if not data.get("peer_maxprefix4"):
-            data["peer_maxprefix4"] = 0
-
-        if not data.get("peer_maxprefix6"):
-            data["peer_maxprefix6"] = 0
-
-        serializer = Serializers.update_peer_session(data=data, context={"asn": asn})
-
-        serializer.is_valid(raise_exception=True)
-
-        peer_session = serializer.save()
-
-        return Response(self.serializer_class(peer_session).data)
-
-    @action(
-        detail=False,
-        methods=["post"],
-        serializer_class=Serializers.update_peer_session,
-    )
-    @load_object("net", models.Network, asn="asn")
-    @grainy_endpoint(namespace="verified.asn.{asn}.?")
-    def create_partial(self, request, asn, net, port_pk, *args, **kwargs):
-        return self.create_floating(request, asn, net, port_pk, *args, **kwargs)
-
-    @load_object("net", models.Network, asn="asn")
-    @grainy_endpoint(namespace="verified.asn.{asn}.?")
-    def update(self, request, asn, net, port_pk, pk, *args, **kwargs):
-        data = request.data.copy()
-        session = models.PeerSession.objects.get(pk=pk, peer_port__peer_net__net=net)
-
-        if not data.get("peer_maxprefix4"):
-            data["peer_maxprefix4"] = 0
-
-        if not data.get("peer_maxprefix6"):
-            data["peer_maxprefix6"] = 0
-
-        serializer = Serializers.update_peer_session(
-            session, data=data, context={"asn": asn}
-        )
-
-        serializer.is_valid(raise_exception=True)
-
-        peer_session = serializer.save()
-
-        return Response(self.serializer_class(peer_session).data)
-
-    @action(
-        detail=True,
-        methods=["put"],
-        serializer_class=Serializers.update_peer_session_meta,
-    )
-    @load_object("net", models.Network, asn="asn")
-    @grainy_endpoint(namespace="verified.asn.{asn}.?")
-    def update_meta(self, request, asn, net, port_pk, pk, *args, **kwargs):
-        data = request.data.copy()
-        session = models.PeerSession.objects.get(pk=pk, peer_port__peer_net__net=net)
-
-        serializer = Serializers.update_peer_session_meta(
-            session, data=data, context={}
-        )
-
-        if "meta4" not in data:
-            data["meta4"] = session.meta4 or None
-
-        if "meta6" not in data:
-            data["meta6"] = session.meta6 or None
-
-        serializer.is_valid(raise_exception=True)
-        peer_session = serializer.save()
-        return Response(self.serializer_class(peer_session).data)
+        return response
 
 
 @route
@@ -1100,7 +1000,7 @@ class UpdatePeerSession(CachedObjectMixin, viewsets.ModelViewSet):
         """
         Handles saving of peer session data (both creation an update)
 
-        Unique sessions are identified by port (ip) + peer asn + peer ip
+        Unique sessions are identified by device or port (ip) + peer asn + peer ip
 
         If a peer session already exists, it is updated, otherwise a new
         session is created.
@@ -1130,8 +1030,6 @@ class UpdatePeerSession(CachedObjectMixin, viewsets.ModelViewSet):
         valid_slz.is_valid(raise_exception=True)
 
         data = valid_slz.validated_data
-
-        print(data)
 
         if data.get("id"):
             # id is specified, so thats the session to update
@@ -1164,6 +1062,50 @@ class UpdatePeerSession(CachedObjectMixin, viewsets.ModelViewSet):
         serializer.save()
 
         return Response(serializer.data)
+
+    @load_object("net", models.Network, asn="asn")
+    @grainy_endpoint(namespace="verified.asn.{asn}.?")
+    def destroy(self, request, asn, net, *args, **kwargs):
+        """
+        Handles deletion of a peer session
+
+        Unique sessions are identified by port (ip) + peer asn + peer ip
+        """
+
+        data = request.data
+
+        if "id" in data and not data["id"]:
+            data.pop("id")
+
+        valid_slz = Serializers.update_peer_session(data=data, context={"asn": asn})
+        valid_slz.is_valid(raise_exception=True)
+
+        data = valid_slz.validated_data
+
+        if data.get("id"):
+            # id is specified, so thats the session to update
+            session = models.PeerSession.objects.get(
+                pk=data["id"], peer_port__peer_net__net=net
+            )
+        else:
+            # other wise we use the unique fields to find the session
+            session = models.PeerSession.get_unique(
+                asn,
+                data["device"],
+                data["peer_asn"],
+                data.get("peer_ip4") or data.get("peer_ip6"),
+            )
+
+        if not session:
+            return Response({}, status=404)
+
+        response = Response(valid_slz.data)
+
+        session.delete()
+
+        return response
+
+
 
 
 @route

--- a/src/django_peerctl/rest/views/peerctl.py
+++ b/src/django_peerctl/rest/views/peerctl.py
@@ -902,16 +902,12 @@ class PeerSession(CachedObjectMixin, viewsets.ModelViewSet):
 
         # check if session exists
 
-        print("IP4", member.ipaddr4)
-
         session_exists = models.PeerSession.get_unique(
             asn,
             port.device_id,
             member.asn,
             member.ipaddr4 or member.ipaddr6,
         )
-
-        print("SESSION EXISTS", session_exists)
 
         if not session_exists:
             peer_port = models.PeerPort.get_or_create_from_members(

--- a/src/django_peerctl/rest/views/peerctl.py
+++ b/src/django_peerctl/rest/views/peerctl.py
@@ -665,7 +665,7 @@ class Peer(CachedObjectMixin, viewsets.GenericViewSet):
         peer = get_member(pk)
         serializer = self.serializer_class(peer, context={"port": port, "net": net})
         return Response(serializer.data)
-    
+
     @action(detail=True, methods=["get"])
     @load_object("net", models.Network, asn="asn")
     @grainy_endpoint(namespace="verified.asn.{asn}.?")
@@ -890,7 +890,6 @@ class PeerSession(CachedObjectMixin, viewsets.ModelViewSet):
         if not port:
             return Response({}, status=404)
 
-
         member = get_member(data.get("member"), join="ix")
 
         if data.get("through"):
@@ -1104,8 +1103,6 @@ class UpdatePeerSession(CachedObjectMixin, viewsets.ModelViewSet):
         session.delete()
 
         return response
-
-
 
 
 @route

--- a/src/django_peerctl/static/peerctl/v2/peerctl.css
+++ b/src/django_peerctl/static/peerctl/v2/peerctl.css
@@ -26,6 +26,11 @@ button.peer_session-live {
   margin-left: -15px;
 }
 
+button.peer_session-add:disabled,
+button.peer_session-live:disabled {
+  opacity: 0.5;
+}
+
 .peers-row {
   border-right: 1px solid var(--clr-border-400);
   border-top: 1px solid var(--clr-border-400);
@@ -60,6 +65,13 @@ div.peers-row.border-inactive .border-show {
 
 div.peers-row.border-active .border-show {
   border-color: var(--clr-accent-400);
+}
+
+div.peers-row div.loading-indicator-container {
+  height:20px;
+  width:20px;
+  vertical-align: middle;
+  display:inline-block;
 }
 
 .secondary .property .field [data-field="peeringdb"] .icon {

--- a/src/django_peerctl/static/peerctl/v2/peerctl.js
+++ b/src/django_peerctl/static/peerctl/v2/peerctl.js
@@ -932,7 +932,6 @@ $peerctl.PeeringLists = $tc.extend(
 
       $(this.$w.devicectl_device.element).on("change", function() {
         devicectl_port.device_id = $(this).val();
-        debugger;
         devicectl_port.load();
         //this.$w.port_device_template.load();
       });
@@ -1909,7 +1908,6 @@ $peerctl.PeerSessionList = $tc.extend(
 
 
         if(data.peer_session_status == "ok") {
-          debugger;
           button_live.element.data("peer_session-id", data.peer_session);
           port_row.addClass("peer_session-active").removeClass("peer_session-inactive");
           if(peer_row)

--- a/src/django_peerctl/static/peerctl/v2/peerctl.js
+++ b/src/django_peerctl/static/peerctl/v2/peerctl.js
@@ -130,7 +130,7 @@ var $peerctl = $ctl.application.Peerctl = $tc.extend(
       var i, app = this;
       for(i in this.$t) {
         if(this.$t[i].active && this.$t[i] != tool) {
-          this.$t[i].sync(app);
+          this.$t[i].sync();
         }
       }
     },
@@ -689,7 +689,8 @@ $peerctl.Networks = $tc.extend(
     },
 
     sync : function() {
-      this.$w.list.load();
+      if(this.select_network_search.val())
+        this.$w.list.load();
     },
 
     get_number_of_selected_networks() {
@@ -775,7 +776,8 @@ $peerctl.PeeringLists = $tc.extend(
         else
           select.val(select.find('option').first().val());
         this.$w.devicectl_port.device_id = select.val();
-        this.$w.devicectl_port.load();
+        if(this.$w.devicectl_port.device_id)
+          this.$w.devicectl_port.load();
       });
 
       $(this.$w.select_port.element).on("change", () => {
@@ -930,6 +932,7 @@ $peerctl.PeeringLists = $tc.extend(
 
       $(this.$w.devicectl_device.element).on("change", function() {
         devicectl_port.device_id = $(this).val();
+        debugger;
         devicectl_port.load();
         //this.$w.port_device_template.load();
       });
@@ -1883,7 +1886,14 @@ $peerctl.PeerSessionList = $tc.extend(
           if(peer_row)
             peer_row.addClass("border-active").removeClass("border-inactive");
           list.fill_policy_selects(port_row, data);
-          button_live.element.data("peer_session-id", response.first().peer_session);
+
+          $(response.first().ipaddr).each(function() {
+            if(this.ipaddr4 == data.ipaddr4 && this.ipaddr6 == data.ipaddr6) {
+              button_live.element.data("peer_session-id", this.peer_session);
+            }
+          });
+
+          
           fullctl.peerctl.$t.peering_lists.$w.peers.update_counts();
           fullctl.peerctl.sync_except(fullctl.peerctl.$t.peering_lists);
         });
@@ -1899,6 +1909,7 @@ $peerctl.PeerSessionList = $tc.extend(
 
 
         if(data.peer_session_status == "ok") {
+          debugger;
           button_live.element.data("peer_session-id", data.peer_session);
           port_row.addClass("peer_session-active").removeClass("peer_session-inactive");
           if(peer_row)

--- a/src/django_peerctl/templates/peerctl/v2/tool/peering-lists/main.html
+++ b/src/django_peerctl/templates/peerctl/v2/tool/peering-lists/main.html
@@ -165,7 +165,7 @@
       <div class="list-no-data">No entries found</div>
       <div class="templates">
         <div data-template="row" class="row secondary">
-          <div class="col-xs-12 col-3 indent-toggled">
+          <div class="col-xs-12 col-3 indent-toggled" style="position:relative">
             <button
               class="peer_session-add peer_session-inactive-toggled solid-inactive"
               data-api-base="{% url "peerctl_api:peer_session-list" asn=selected_asn port_pk="port_id" %}"
@@ -176,7 +176,9 @@
               data-api-base="{% url "peerctl_api:peer_session-detail" asn=selected_asn port_pk="port_id"  pk="peer_session_id" %}"
               data-confirm="{% trans "Remove this peering session?" %}"
               data-api-method="delete">{% trans "Live" %}</button>
-
+            <div class="loading-indicator-container" style="display:none;">
+              <div class="loading-indicator"></div>
+            </div>
             <span data-field="ix_name"></span>
           </div>
           <div class="col-xs-12 col-3">

--- a/src/django_peerctl/templates/peerctl/v2/tool/peering-summary-sessions/form-manual-session.html
+++ b/src/django_peerctl/templates/peerctl/v2/tool/peering-summary-sessions/form-manual-session.html
@@ -54,13 +54,13 @@
     </div>
     <div class="row | mb-3 ms-1">
       <div class="col" data-api-submit="yes">
-        <label class="form-label" for="policy_4">{% trans "Policy" %}</label>
+        <label class="form-label" for="policy4">{% trans "Policy" %}</label>
         <span class="modal-control">
         <img class="caret" src="{% static "common/icons/ui-caret-caret/down.svg" %}">
         <select
           class="form-control"
           id="policy-4"
-          name="policy_4"
+          name="policy4"
           data-api-load="yes"
           data-api-base="{% url "peerctl_api:policy-list" asn=selected_asn %}"
           data-null-option=";{% trans "Inherit Policy" %}">
@@ -77,13 +77,13 @@
     </div>
     <div class="row | mb-3 ms-1">
       <div class="col" data-api-submit="yes">
-        <label class="form-label" for="policy_6">{% trans "Policy" %}</label>
+        <label class="form-label" for="policy6">{% trans "Policy" %}</label>
         <span class="modal-control">
         <img class="caret" src="{% static "common/icons/ui-caret-caret/down.svg" %}">
         <select
           class="form-control"
           id="policy-6"
-          name="policy_6"
+          name="policy6"
           data-api-load="yes"
           data-api-base="{% url "peerctl_api:policy-list" asn=selected_asn %}"
           data-null-option=";{% trans "Inherit Policy" %}">


### PR DESCRIPTION
- update sessions: policy_4 to policy4
- update sessions: policy_6 to policy6
- update sessions: add `/remove` endpoint for session removal based on unique identifiers
- fix several invalid requests fired off from the UX during operations
- fix manually updated / added sessions not showing in peering list
- remove old session cruft
- fix peering list session create / delete bugs
- added loading indicators for adding/removing sessions through peering lists