### PR TITLE
20230529 fixes

### DIFF
--- a/src/django_peerctl/models/peerctl.py
+++ b/src/django_peerctl/models/peerctl.py
@@ -1465,26 +1465,26 @@ class PortInfo(sot.ReferenceMixin, Base):
         ip4 = ipaddress.ip_interface(self.ipaddr4) if self.ipaddr4 else None
         ip6 = ipaddress.ip_interface(self.ipaddr6) if self.ipaddr6 else None
 
-        other_ip4 = ipaddress.ip_interface(port_info.ipaddr4) if port_info.ipaddr4 else None
-        other_ip6 = ipaddress.ip_interface(port_info.ipaddr6) if port_info.ipaddr6 else None
+        other_ip4 = (
+            ipaddress.ip_interface(port_info.ipaddr4) if port_info.ipaddr4 else None
+        )
+        other_ip6 = (
+            ipaddress.ip_interface(port_info.ipaddr6) if port_info.ipaddr6 else None
+        )
 
         if ip4 and other_ip4:
             network4 = ip4.network if ip4.network.prefixlen < 32 else other_ip4.network
-        
+
         if ip6 and other_ip6:
             network6 = ip6.network if ip6.network.prefixlen < 128 else other_ip6.network
 
         if ip4 and other_ip4:
-            return (other_ip4.ip in network4 and ip4.ip in network4)
+            return other_ip4.ip in network4 and ip4.ip in network4
 
         if ip6 and other_ip6:
-            return (other_ip6.ip in network6 and ip6.ip in network6)
-    
+            return other_ip6.ip in network6 and ip6.ip in network6
+
         return False
-
-        
-
-
 
 
 class DeviceObject(devicectl.DeviceCtlEntity):

--- a/src/django_peerctl/models/peerctl.py
+++ b/src/django_peerctl/models/peerctl.py
@@ -1454,6 +1454,38 @@ class PortInfo(sot.ReferenceMixin, Base):
         self.save()
         SyncIsRsPeer.create_task(self.net.asn, self.ipaddr4, self.is_route_server_peer)
 
+    def in_same_subnet(self, port_info):
+        """
+        Checks if the supplied port info is in the same subnet as this port info
+
+        prefix length will be determined by either port_info's ip interface, checking
+        self first, then the other port info
+        """
+
+        ip4 = ipaddress.ip_interface(self.ipaddr4) if self.ipaddr4 else None
+        ip6 = ipaddress.ip_interface(self.ipaddr6) if self.ipaddr6 else None
+
+        other_ip4 = ipaddress.ip_interface(port_info.ipaddr4) if port_info.ipaddr4 else None
+        other_ip6 = ipaddress.ip_interface(port_info.ipaddr6) if port_info.ipaddr6 else None
+
+        if ip4 and other_ip4:
+            network4 = ip4.network if ip4.network.prefixlen < 32 else other_ip4.network
+        
+        if ip6 and other_ip6:
+            network6 = ip6.network if ip6.network.prefixlen < 128 else other_ip6.network
+
+        if ip4 and other_ip4:
+            return (other_ip4.ip in network4 and ip4.ip in network4)
+
+        if ip6 and other_ip6:
+            return (other_ip6.ip in network6 and ip6.ip in network6)
+    
+        return False
+
+        
+
+
+
 
 class DeviceObject(devicectl.DeviceCtlEntity):
     @property

--- a/src/django_peerctl/rest/serializers/peerctl.py
+++ b/src/django_peerctl/rest/serializers/peerctl.py
@@ -912,7 +912,7 @@ class UpdatePeerSession(serializers.Serializer):
         elif peer_ip4:
             filters.append(Q(ip_address_4__host=peer_ip4.ip))
         elif peer_ip6:
-            filters.append(Q(ip_address_6__host=peer_ip4.ip))
+            filters.append(Q(ip_address_6__host=peer_ip6.ip))
 
         # filter arguments for PortInfo object
 
@@ -1057,11 +1057,12 @@ class UpdatePeerSession(serializers.Serializer):
         if old_md5 != peer_net.md5 and session.port:
             peer_net.sync_route_server_md5()
 
-        self.ensure_peer_portinfo(
+        peer_port_info = self.ensure_peer_portinfo(
             net, data.get("peer_ip4"), data.get("peer_ip6"), data.get("port")
         )
 
         session.peer_port.peer_net = peer_net
+        session.peer_port.port_info = peer_port_info
 
         if "peer_interface" in data:
             session.peer_port.interface_name = data["peer_interface"]

--- a/src/django_peerctl/rest/views/peerctl.py
+++ b/src/django_peerctl/rest/views/peerctl.py
@@ -441,7 +441,7 @@ class NetworkSearch(viewsets.GenericViewSet):
                     source = port_info.ref_source
                 except sot.ReferenceNotSetError:
                     source = None
-                
+
                 if source == "pdbctl" and port_info.ref.ix_id == f"pdbctl:{ix_id}":
                     loc_data["session"] = True
                     break
@@ -453,12 +453,12 @@ class NetworkSearch(viewsets.GenericViewSet):
                         loc_data["session"] = True
                         break
                 elif session.port:
-                    # the peer port does not have a direct reference to a 
+                    # the peer port does not have a direct reference to a
                     # pdbctl networkixlan or ixctl internet exchange member
                     # so we check by ip-address match instead.
 
                     ses_port_info = session.port.object.port_info_object
-                    
+
                     loc_data["session"] = ses_port_info.in_same_subnet(port_info)
 
         result["their_locations"] = sorted(


### PR DESCRIPTION
- fixes issue with `update_peer_session` if only an ipv6 is supplied
- fixes issue with `network search` if a mutual location had an active session where the session port was not created from a pdbctl or ixctl reference